### PR TITLE
Command fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Queues all products for renewal, this will be done in the next cron run.
 * apw:run-product-renewal
 
 Runs the product renewal immediately without waiting for cron. When the request limit is reached,
-this command will stop. To force the command to go through all products until they are all updates,
-use the --force flag.
+this command will stop and show the number of products still waiting for renewal. You can run it
+multiple times to update all products.
 
 * apw:stale
 

--- a/src/Commands/AmazonProductWidgetCommands.php
+++ b/src/Commands/AmazonProductWidgetCommands.php
@@ -67,11 +67,12 @@ class AmazonProductWidgetCommands extends DrushCommands {
     if (!empty($asins)) {
       try {
         $this->productService->queueProductRenewal($asins);
-        $this->io()->note(count($asins) . " have been queued for renewal.");
+        $count = count($asins);
+        $this->output()->writeln("$count products have been queued for renewal.");
       }
       catch (\Exception $exception) {
-        $this->io()->warning("An unrecoverable error has occurred:");
-        $this->io()->warning($exception->getMessage());
+        $this->output()->writeln("An unrecoverable error has occurred:");
+        $this->output()->writeln($exception->getMessage());
       }
     }
   }
@@ -110,10 +111,10 @@ class AmazonProductWidgetCommands extends DrushCommands {
       if ($this->productService->getProductStore()->hasStaleData() && $options['force']) {
         goto repeat;
       }
-      $this->io()->note("All items have been processed.");
+      $this->output()->writeln("All items have been processed.");
     }
     else {
-      $this->io()->note("There is nothing to update.");
+      $this->output()->writeln("There is nothing to update.");
     }
   }
 
@@ -124,7 +125,7 @@ class AmazonProductWidgetCommands extends DrushCommands {
    */
   public function itemsDueForRenewal() {
     $outdated = $this->productService->getProductStore()->getOutdatedKeysCount();
-    $this->io()->note("There are " . $outdated . " products waiting for renewal.");
+    $this->output()->writeln("There are $outdated products waiting for renewal.");
   }
 
   /**
@@ -140,16 +141,16 @@ class AmazonProductWidgetCommands extends DrushCommands {
     try {
       $productData = $this->productService->getProductData([$asin]);
       if (isset($productData[$asin]['overrides'])) {
-        $this->io()->note("The following overrides were found for: $asin");
-        $this->io()->note(var_export($productData[$asin]['overrides'], TRUE));
+        $this->output()->writeln("The following overrides were found for: $asin");
+        $this->output()->writeln(var_export($productData[$asin]['overrides'], TRUE));
       }
       else {
-        $this->io()->warning("No product with ASIN $asin has been found.");
+        $this->output()->writeln("No product with ASIN $asin has been found.");
       }
     }
     catch (\Exception $exception) {
-      $this->io()->warning("An unexpected error has occurred:");
-      $this->io()->warning($exception->getMessage());
+      $this->output()->writeln("An unexpected error has occurred:");
+      $this->output()->writeln($exception->getMessage());
     }
   }
 
@@ -160,5 +161,6 @@ class AmazonProductWidgetCommands extends DrushCommands {
    */
   public function resetAllRenewals() {
     $this->productService->getProductStore()->resetAll();
+    $this->output()->writeln("All products have been marked for renewal.");
   }
 }

--- a/src/Commands/AmazonProductWidgetCommands.php
+++ b/src/Commands/AmazonProductWidgetCommands.php
@@ -86,7 +86,6 @@ class AmazonProductWidgetCommands extends DrushCommands {
    */
   public function updateProductData() {
     $queue = $this->queue->get('amazon_product_widget.product_data_update');
-    repeat:
     if ($this->productService->getProductStore()->hasStaleData()) {
       $this->productService->queueProductRenewal();
 

--- a/src/Commands/AmazonProductWidgetCommands.php
+++ b/src/Commands/AmazonProductWidgetCommands.php
@@ -81,12 +81,10 @@ class AmazonProductWidgetCommands extends DrushCommands {
    * Updates all product data.
    *
    * @command apw:run-product-renewal
-   * @option force
-   *   Forces the command to run until all products have been updated.
    *
    * @throws \Exception
    */
-  public function updateProductData($options = ['force' => FALSE]) {
+  public function updateProductData() {
     $queue = $this->queue->get('amazon_product_widget.product_data_update');
     repeat:
     if ($this->productService->getProductStore()->hasStaleData()) {
@@ -108,10 +106,13 @@ class AmazonProductWidgetCommands extends DrushCommands {
         }
       }
 
-      if ($this->productService->getProductStore()->hasStaleData() && $options['force']) {
-        goto repeat;
+      if ($this->productService->getProductStore()->hasStaleData()) {
+        $outdated = $this->productService->getProductStore()->getOutdatedKeysCount();
+        $this->output()->writeln("There are $outdated products still remaining.");
       }
-      $this->output()->writeln("All items have been processed.");
+      else {
+        $this->output()->writeln("All items have been processed.");
+      }
     }
     else {
       $this->output()->writeln("There is nothing to update.");

--- a/src/ProductStore.php
+++ b/src/ProductStore.php
@@ -237,8 +237,7 @@ class ProductStore extends DatabaseStorage {
     $query = $this->connection->select($this->table, 'ta');
     $query->condition('collection', $this->collection);
     $query->condition('renewal', $this->time->getRequestTime(), '<');
-    $query->countQuery();
-    return $query->execute()->fetchField();
+    return $query->countQuery()->execute()->fetchField();
   }
 
   /**


### PR DESCRIPTION
Replaced `io()` with `output()` since it is more consistent with Drush style output.

Also fixed the count query in `getOutdatedKeysCount()`.

Lastly, removed the `--force` option from `apw:run-product-renewal`, the user has to run the command multiple times to refresh all products manually. Updated README to reflect this change.